### PR TITLE
Update terra.go to use the proper terra 2 endpoint

### DIFF
--- a/core/chains/terra.go
+++ b/core/chains/terra.go
@@ -38,7 +38,7 @@ type TerraErrorResponse struct {
 // https://fcd.terra.dev/swagger
 func Terra() (int, error) {
 	votingPowers := make([]int64, 0, 200)
-	url := fmt.Sprintf("https://fcd.terra.dev/validatorsets/latest")
+	url := fmt.Sprintf("https://phoenix-lcd.terra.dev/validatorsets/latest")
 	resp, err := http.Get(url)
 	if err != nil {
 		errBody, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Current endpoint refers to Terra Classic

Also changed from fcd to LCD (current fcd endpoints is just proxied to LCD anyway)