### PR TITLE
Fix Mina threshold to correspond to Ouroboros

### DIFF
--- a/core/chains/mina.go
+++ b/core/chains/mina.go
@@ -87,7 +87,7 @@ func Mina() (int, error) {
 }
 
 func calcNakamotoCoefficientForMina(votingPowers []float64) int {
-	var cumulativePercent, thresholdPercent float64 = 0.00, utils.THRESHOLD_PERCENT
+	var cumulativePercent, thresholdPercent float64 = 0.00, 50.00
 	nakamotoCoefficient := 0
 	for _, vpp := range votingPowers {
 		// since this is the  actual voting percentage, no need to multiply with 100

--- a/core/chains/mina.go
+++ b/core/chains/mina.go
@@ -87,6 +87,7 @@ func Mina() (int, error) {
 }
 
 func calcNakamotoCoefficientForMina(votingPowers []float64) int {
+        // Mina uses Ouroboros which uses 50% of the total voting paper. Paper link: https://eprint.iacr.org/2017/573.pdf (Page 6)
 	var cumulativePercent, thresholdPercent float64 = 0.00, 50.00
 	nakamotoCoefficient := 0
 	for _, vpp := range votingPowers {


### PR DESCRIPTION
If I'm reading this right, the voting power threshold being used is the default of 33%

Ouroboros which Mina uses however, is able to use 50% for its voting threshold. See the [Ouroboros Praos paper](https://eprint.iacr.org/2017/573.pdf) for details (or happy to follow up with more information).