### PR TITLE
Use a public rpc for nano

### DIFF
--- a/core/chains/nano.go
+++ b/core/chains/nano.go
@@ -75,7 +75,7 @@ func nanoRequest[ReqType any, ResType any](url string, req ReqType) (*ResType, e
 }
 
 func Nano() (int, error) {
-	rpc := "http://localhost:7076"
+	rpc := "https://mynano.ninja/api/node"
 	richlist := "https://nano.nendly.com/nakamoto/richlist"
 
 	bigFromStr := func(value string) (*big.Int, error) {


### PR DESCRIPTION
Updates the nano backend to use My Nano Ninja's public nano rpc rather than a local node