### PR TITLE
fix cosmos, regen and terra

### DIFF
--- a/core/chains/cosmos.go
+++ b/core/chains/cosmos.go
@@ -28,7 +28,7 @@ func Cosmos() (int, error) {
 	var (
 		votingPowers []big.Int
 		response     cosmosResponse
-		url          = "https://cosmos.lcd.atomscan.com/cosmos/staking/v1beta1/validators?page.offset=1&pagination.limit=500&status=BOND_STATUS_BONDED"
+		url          = "https://proxy.atomscan.com/cosmoshub-lcd/cosmos/staking/v1beta1/validators?page.offset=1&pagination.limit=500&status=BOND_STATUS_BONDED"
 		err          error
 	)
 

--- a/core/chains/ethereum2.go
+++ b/core/chains/ethereum2.go
@@ -52,6 +52,7 @@ func Eth2() (int, error) {
 		log.Println(err)
 		return 0, errors.New("get request unsuccessful")
 	}
+	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/core/chains/terra.go
+++ b/core/chains/terra.go
@@ -1,55 +1,49 @@
 package chains
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
-	utils "github.com/xenowits/nakamoto-coefficient-calculator/core/utils"
+	"github.com/xenowits/nakamoto-coefficient-calculator/core/utils"
 )
 
 type TerraResponse struct {
-	Jsonrpc string `json:"jsonrpc"`
-	Id      int    `json:"id"`
-	Result  struct {
-		Block_height string
-		Validators   []struct {
-			Address           string `json:"address"`
-			Voting_power      string `json:"voting_power"`
-			Proposer_priority string `json:"proposer_priority"`
-			Pub_key           struct {
-				Type  string `json:"type"`
-				Value string `json:"value"`
-			} `json:"pub_key"`
-		} `json:"validators"`
-		Total string `json:"total"`
-	} `json:"result"`
+	Validators []struct {
+		Voting_power      string `json:"voting_power"`
+		Proposer_priority string `json:"proposer_priority"`
+	} `json:"validators"`
 }
 
-type TerraErrorResponse struct {
-	Id      int    `json:"id"`
-	Jsonrpc string `json:"jsonrpc"`
-	Error   string `json:"error"`
-}
-
+// Terra returns the NC value for terra blockchain.
+//
 // https://fcd.terra.dev/swagger
 func Terra() (int, error) {
 	votingPowers := make([]int64, 0, 200)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelFunc()
+
 	url := fmt.Sprintf("https://phoenix-lcd.terra.dev/validatorsets/latest")
-	resp, err := http.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		errBody, _ := ioutil.ReadAll(resp.Body)
-		var errResp TerraErrorResponse
-		json.Unmarshal(errBody, &errResp)
-		log.Println(errResp.Error)
-		return 0, err
+		log.Println(err)
+		return 0, errors.New("create get request for terra")
+	}
+
+	resp, err := new(http.Client).Do(req)
+	if err != nil {
+		log.Println(err)
+		return 0, errors.New("get request unsuccessful")
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err
 	}
@@ -61,7 +55,7 @@ func Terra() (int, error) {
 	}
 
 	// loop through the validators voting powers
-	for _, ele := range response.Result.Validators {
+	for _, ele := range response.Validators {
 		val, _ := strconv.Atoi(ele.Voting_power)
 		votingPowers = append(votingPowers, int64(val))
 	}


### PR DESCRIPTION
Fixes cosmos, regen and terra NC calculation.

category: fix
ticket: https://github.com/xenowits/nakomoto-coefficient-calculator/issues/24

* The data endpoint for cosmos changed
* Handle regen endpoint returning a mix of int and string values
* Handle changed terra response structure