### PR TITLE
add Stargaze blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ NOTE: You can get your API Key by signing up [here](https://www.validators.app/u
 14. [Regen Network](https://www.regen.network/)
 15. [Agoric](https://agoric.com/)
 16. [Nano](https://nano.org/)
+17. [Stargaze](https://stargaze.zone/)
 
 ### Notes
 

--- a/core/chains/chain.go
+++ b/core/chains/chain.go
@@ -1,7 +1,6 @@
 package chains
 
 import (
-	"errors"
 	"fmt"
 	"log"
 )
@@ -36,6 +35,7 @@ const (
 	REGEN Token = "REGEN"
 	RUNE  Token = "RUNE"
 	SOL   Token = "SOL"
+	STARS Token = "STARS"
 	XNO   Token = "XNO"
 )
 
@@ -72,6 +72,8 @@ func (t Token) ChainName() string {
 		return "Thorchain"
 	case SOL:
 		return "Solana"
+	case STARS:
+		return "Stargaze"
 	case XNO:
 		return "Nano"
 	default:
@@ -79,7 +81,7 @@ func (t Token) ChainName() string {
 	}
 }
 
-var Tokens = []Token{ATOM, AVAX, BLD, BNB, ETH2, GRT, JUNO, LUNA, MATIC, MINA, NEAR, OSMO, REGEN, RUNE, SOL, XNO}
+var Tokens = []Token{ATOM, AVAX, BLD, BNB, ETH2, GRT, JUNO, LUNA, MATIC, MINA, NEAR, OSMO, REGEN, RUNE, SOL, STARS, XNO}
 
 // NewState returns a new fresh state.
 func NewState() ChainState {
@@ -143,10 +145,12 @@ func newValues(token Token) (int, error) {
 		currVal, err = Thorchain()
 	case SOL:
 		currVal, err = Solana()
+	case STARS:
+		currVal, err = Stargaze()
 	case XNO:
 		currVal, err = Nano()
 	default:
-		return 0, errors.New(fmt.Sprintf("chain not found %s\n", token))
+		return 0, fmt.Errorf("chain not found %s", token)
 	}
 
 	return currVal, err

--- a/core/chains/cosmos.go
+++ b/core/chains/cosmos.go
@@ -27,10 +27,11 @@ type cosmosResponse struct {
 
 func Cosmos() (int, error) {
 	url := "https://proxy.atomscan.com/cosmoshub-lcd/cosmos/staking/v1beta1/validators?page.offset=1&pagination.limit=500&status=BOND_STATUS_BONDED"
-	return fetchCosmosSDKNakamotoCoefficient("cosmos", url)
+	return fetchCosmosSDKNakaCoeff("cosmos", url)
 }
 
-func fetchCosmosSDKNakamotoCoefficient(chainName, url string) (int, error) {
+// fetchCosmosSDKNakaCoeff returns the nakamoto coefficient for the provided cosmos SDK-based chain using the provided url.
+func fetchCosmosSDKNakaCoeff(chainName, url string) (int, error) {
 	var (
 		votingPowers []big.Int
 		response     cosmosResponse

--- a/core/chains/stargaze.go
+++ b/core/chains/stargaze.go
@@ -2,5 +2,5 @@ package chains
 
 func Stargaze() (int, error) {
 	url := "https://rest.stargaze-apis.com/cosmos/staking/v1beta1/validators?page.offset=1&pagination.limit=500&status=BOND_STATUS_BONDED"
-	return fetchCosmosSDKNakamotoCoefficient("stargaze", url)
+	return fetchCosmosSDKNakaCoeff("stargaze", url)
 }

--- a/core/chains/stargaze.go
+++ b/core/chains/stargaze.go
@@ -1,0 +1,6 @@
+package chains
+
+func Stargaze() (int, error) {
+	url := "https://rest.stargaze-apis.com/cosmos/staking/v1beta1/validators?page.offset=1&pagination.limit=500&status=BOND_STATUS_BONDED"
+	return fetchCosmosSDKNakamotoCoefficient("stargaze", url)
+}


### PR DESCRIPTION
This PR adds Stargaze a Cosmos SDK based blockchain. [Cosmos SDK](cosmos.network)  chains usually have the same APIs to retrieve the list of validators and voting power and I have abstracted the work made for cosmos hub chain to just point to the specific chain endpoint and name.


<img width="664" alt="Screenshot 2023-08-16 at 9 24 15 AM" src="https://github.com/xenowits/nakomoto-coefficient-calculator/assets/3452489/bf8a76ef-6773-4cc1-954d-7db6f3394888">


### About Stargaze
Stargaze is "The Interchain" NFT marketplace being the first interoperable layer-1 chain for NFTs. Stargaze is the app specific chain for NFTs in the Cosmos.

https://stargaze.zone
https://twitter.com/StargazeZone