### PR TITLE
Adding support for Hedera

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ NOTE: You can get your API Key by signing up [here](https://www.validators.app/u
 15. [Agoric](https://agoric.com/)
 16. [Nano](https://nano.org/)
 17. [Stargaze](https://stargaze.zone/)
+18. [Hedera](https://hedera.com/)
 
 ### Notes
 

--- a/core/chains/chain.go
+++ b/core/chains/chain.go
@@ -26,6 +26,7 @@ const (
 	BNB   Token = "BNB"
 	ETH2  Token = "ETH2"
 	GRT   Token = "GRT"
+	HBAR  Token = "HBAR"
 	JUNO  Token = "JUNO"
 	LUNA  Token = "LUNA" // TODO(xenowits): Remove terra Chain from codebase
 	MATIC Token = "MATIC"
@@ -54,6 +55,8 @@ func (t Token) ChainName() string {
 		return "Ethereum Proof-of-Stake"
 	case GRT:
 		return "Graph Protocol"
+	case HBAR:
+		return "Hedera"
 	case JUNO:
 		return "Juno"
 	case LUNA:
@@ -81,7 +84,7 @@ func (t Token) ChainName() string {
 	}
 }
 
-var Tokens = []Token{ATOM, AVAX, BLD, BNB, ETH2, GRT, JUNO, LUNA, MATIC, MINA, NEAR, OSMO, REGEN, RUNE, SOL, STARS, XNO}
+var Tokens = []Token{ATOM, AVAX, BLD, BNB, ETH2, GRT, HBAR, JUNO, LUNA, MATIC, MINA, NEAR, OSMO, REGEN, RUNE, SOL, STARS, XNO}
 
 // NewState returns a new fresh state.
 func NewState() ChainState {
@@ -127,6 +130,8 @@ func newValues(token Token) (int, error) {
 		currVal, err = Eth2()
 	case GRT:
 		currVal, err = Graph()
+	case HBAR:
+		currVal, err = Hedera()
 	case JUNO:
 		currVal, err = Juno()
 	case LUNA:

--- a/core/chains/hedera.go
+++ b/core/chains/hedera.go
@@ -39,7 +39,7 @@ func Hedera() (int, error){
 	// Loop over api responses for all pages.
 	for {
 		// Get response from API.
-		resp, err := http.Get(baseURL + query)
+		resp, err := http.Get(fmt.Sprintf("%s%s", baseURL, query))
 		if err != nil {
 			fmt.Println(err)
 			return 0, err

--- a/core/chains/hedera.go
+++ b/core/chains/hedera.go
@@ -10,6 +10,8 @@ import (
 	utils "github.com/xenowits/nakamoto-coefficient-calculator/core/utils"
 )
 
+const TinyToHbar = 100_000_000 // Tinybar to Hbar.
+
 type Node []struct {
 	Description     string `json:"description"`
 	Node_Account    string `json:"node_account_id"`
@@ -56,7 +58,7 @@ func Hedera() (int, error){
 		
 		// Append node votes to array (from response).
 		for _, node := range response.Nodes {
-			votingPowers = append(votingPowers, *big.NewInt(node.Stake/100000000)) // Convert tinybar to hbar.
+			votingPowers = append(votingPowers, *big.NewInt(node.Stake/TinyToHbar)) // Convert tinybar to hbar.
 		}
 
 		// Assign next page of results to parse (null if empty, otherwise string).

--- a/core/chains/hedera.go
+++ b/core/chains/hedera.go
@@ -15,7 +15,7 @@ const TinyToHbar = 100_000_000 // Tinybar to Hbar.
 type Node []struct {
 	Description     string `json:"description"`
 	Node_Account    string `json:"node_account_id"`
-	Stake 			int64  `json:"stake"`
+	Stake           int64  `json:"stake"`
 }
 
 type Link struct{
@@ -65,7 +65,9 @@ func Hedera() (int, error){
 		page = response.Links.Next
 
 		// Break loop where there is no more data.
-		if page == "" || page == "null" { break }
+		if page == "" || page == "null" { 
+			break 
+		}
 
 		// Assign new query to api call and reset page variable.
 		query = page

--- a/core/chains/hedera.go
+++ b/core/chains/hedera.go
@@ -27,7 +27,7 @@ type HederaResponse struct {
 
 func Hedera() (int, error){
 	// Set base url for requests.
-	var base = "https://mainnet-public.mirrornode.hedera.com"
+	var baseURL = "https://mainnet-public.mirrornode.hedera.com"
 	var query = "/api/v1/network/nodes"
 
 	// Declare variable for tracking votes for each node.
@@ -39,7 +39,7 @@ func Hedera() (int, error){
 	// Loop over api responses for all pages.
 	for {
 		// Get response from API.
-		resp, err := http.Get(base + query)
+		resp, err := http.Get(baseURL + query)
 		if err != nil {
 			fmt.Println(err)
 			return 0, err

--- a/core/chains/hedera.go
+++ b/core/chains/hedera.go
@@ -27,19 +27,19 @@ type HederaResponse struct {
 
 func Hedera() (int, error){
 
-	// set base url for requests
+	// Set base url for requests.
 	var base = "https://mainnet-public.mirrornode.hedera.com"
 	var query = "/api/v1/network/nodes"
 
-	// declare variable for tracking votes for each node
+	// Declare variable for tracking votes for each node.
 	var votingPowers []big.Int
 
-	// declare variables for tracking pagination
+	// Declare variables for tracking pagination.
 	var page = ""
 
-	//loop over api responses for all pages
+	// Loop over api responses for all pages.
 	for {
-		//get response from api
+		// Get response from API.
 		resp, err := http.Get(base + query)
 		if err != nil {
 			fmt.Println(err)
@@ -47,7 +47,7 @@ func Hedera() (int, error){
 		}
 		defer resp.Body.Close()
 
-		//decode json response to go objects
+		// Decode json response to go objects.
 		var response HederaResponse
 		err = json.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
@@ -55,32 +55,32 @@ func Hedera() (int, error){
 			return 0, err
 		}
 		
-		// append node votes to array (from response)
+		// Append node votes to array (from response).
 		for _, node := range response.Nodes {
-			votingPowers = append(votingPowers, *big.NewInt(node.Stake/100000000)) //convert tinybar to hbar
+			votingPowers = append(votingPowers, *big.NewInt(node.Stake/100000000)) // Convert tinybar to hbar.
 		}
 
-		// assign next page of results to parse (null if empty, otherwise string)
+		// Assign next page of results to parse (null if empty, otherwise string).
 		page = response.Links.Next
 
-		// break loop where there is no more data
+		// Break loop where there is no more data.
 		if page == "" || page == "null" { break }
 
-		//assign new query to api call and reset page variable
+		// Assign new query to api call and reset page variable.
 		query = page
 		page = ""
 	}
 
-	// sort the node votes in descending order
+	// Sort the node votes in descending order.
 	sort.Slice(votingPowers, func(i, j int) bool {
 		return (&votingPowers[i]).Cmp(&votingPowers[j]) == 1
 	})	
 
-	// calculate the total voting power
+	// Calculate the total voting power.
 	totalVotingPower := utils.CalculateTotalVotingPowerBigNums(votingPowers)
 	fmt.Println("Total voting power for Hedera is:", new(big.Float).SetInt(totalVotingPower))
 
-	// now we're ready to calculate the nakomoto coefficient
+	// Now we're ready to calculate the nakomoto coefficient.
 	nakamotoCoefficient := utils.CalcNakamotoCoefficientBigNums(totalVotingPower, votingPowers)
 	fmt.Println("The Nakamoto coefficient for Hedera is", nakamotoCoefficient)
 

--- a/core/chains/hedera.go
+++ b/core/chains/hedera.go
@@ -26,7 +26,6 @@ type HederaResponse struct {
 }
 
 func Hedera() (int, error){
-
 	// Set base url for requests.
 	var base = "https://mainnet-public.mirrornode.hedera.com"
 	var query = "/api/v1/network/nodes"

--- a/core/chains/hedera.go
+++ b/core/chains/hedera.go
@@ -1,0 +1,88 @@
+package chains
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"sort"
+
+	utils "github.com/xenowits/nakamoto-coefficient-calculator/core/utils"
+)
+
+type Node []struct {
+	Description     string `json:"description"`
+	Node_Account    string `json:"node_account_id"`
+	Stake 			int64  `json:"stake"`
+}
+
+type Link struct{
+	Next	string `json:"next"`
+}
+
+type HederaResponse struct {
+	Nodes	Node
+	Links	Link
+}
+
+func Hedera() (int, error){
+
+	// set base url for requests
+	var base = "https://mainnet-public.mirrornode.hedera.com"
+	var query = "/api/v1/network/nodes"
+
+	// declare variable for tracking votes for each node
+	var votingPowers []big.Int
+
+	// declare variables for tracking pagination
+	var page = ""
+
+	//loop over api responses for all pages
+	for {
+		//get response from api
+		resp, err := http.Get(base + query)
+		if err != nil {
+			fmt.Println(err)
+			return 0, err
+		}
+		defer resp.Body.Close()
+
+		//decode json response to go objects
+		var response HederaResponse
+		err = json.NewDecoder(resp.Body).Decode(&response)
+		if err != nil {
+			fmt.Println(err)
+			return 0, err
+		}
+		
+		// append node votes to array (from response)
+		for _, node := range response.Nodes {
+			votingPowers = append(votingPowers, *big.NewInt(node.Stake/100000000)) //convert tinybar to hbar
+		}
+
+		// assign next page of results to parse (null if empty, otherwise string)
+		page = response.Links.Next
+
+		// break loop where there is no more data
+		if page == "" || page == "null" { break }
+
+		//assign new query to api call and reset page variable
+		query = page
+		page = ""
+	}
+
+	// sort the node votes in descending order
+	sort.Slice(votingPowers, func(i, j int) bool {
+		return (&votingPowers[i]).Cmp(&votingPowers[j]) == 1
+	})	
+
+	// calculate the total voting power
+	totalVotingPower := utils.CalculateTotalVotingPowerBigNums(votingPowers)
+	fmt.Println("Total voting power for Hedera is:", new(big.Float).SetInt(totalVotingPower))
+
+	// now we're ready to calculate the nakomoto coefficient
+	nakamotoCoefficient := utils.CalcNakamotoCoefficientBigNums(totalVotingPower, votingPowers)
+	fmt.Println("The Nakamoto coefficient for Hedera is", nakamotoCoefficient)
+
+	return nakamotoCoefficient, nil	
+}


### PR DESCRIPTION
### Request

This PR adds support for Hedera. We'd love for you to include us over at https://nakaflow.io/ 

### Implementation Notes
- We've implemented support for paginated HTTP requests over to https://mainnet-public.mirrornode.hedera.com/api/v1/network/nodes
- Each node's "stake" property is aggregated, placed in descending order, and passed to the utility calculation for the Nakamoto coefficient.

<img width="258" alt="Hedera" src="https://github.com/xenowits/nakomoto-coefficient-calculator/assets/109120661/c49fa717-b7cb-4bc9-a23c-2f2d285016d0">

### About Hedera
Hedera is an open-source, leaderless proof-of-stake public ledger. Hedera’s robust [ecosystem](https://www.hedera.com/ecosystem/) is built by a global community, on a network governed by a diverse [council](https://www.hedera.com/council) of industry-leading organizations

https://hedera.com/
https://twitter.com/hedera