### PR TITLE
core/chains: fix juno

### DIFF
--- a/core/chains/agoric.go
+++ b/core/chains/agoric.go
@@ -3,7 +3,7 @@ package chains
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"sort"
@@ -13,21 +13,8 @@ import (
 )
 
 type AgoricResponse struct {
-	Height string `json:"height"`
 	Result []struct {
-		OperatorAddress string `json:"operator_address"`
-		ConsensusPubkey struct {
-			Type  string `json:"type"`
-			Value string `json:"value"`
-		} `json:"consensus_pubkey"`
 		Tokens      string `json:"tokens"`
-		Description struct {
-			Moniker         string `json:"moniker"`
-			Identity        string `json:"identity"`
-			Website         string `json:"website"`
-			SecurityContact string `json:"security_contact"`
-			Details         string `json:"details"`
-		} `json:"description"`
 	} `json:"result"`
 }
 
@@ -43,7 +30,7 @@ func Agoric() (int, error) {
 	url := fmt.Sprintf("https://lcd-agoric.keplr.app/staking/validators")
 	resp, err := http.Get(url)
 	if err != nil {
-		errBody, _ := ioutil.ReadAll(resp.Body)
+		errBody, _ := io.ReadAll(resp.Body)
 		var errResp AgoricErrorResponse
 		json.Unmarshal(errBody, &errResp)
 		log.Println(errResp.Error)
@@ -51,7 +38,7 @@ func Agoric() (int, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err
 	}

--- a/core/chains/juno.go
+++ b/core/chains/juno.go
@@ -3,69 +3,49 @@ package chains
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"log"
+	"io"
 	"net/http"
 	"sort"
-	"strconv"
 
 	utils "github.com/xenowits/nakamoto-coefficient-calculator/core/utils"
 )
 
-type JunoResponse struct {
-	Height string `json:"height"`
-	Result []struct {
-		OperatorAddress string `json:"operator_address"`
-		ConsensusPubkey struct {
-			Type  string `json:"type"`
-			Value string `json:"value"`
-		} `json:"consensus_pubkey"`
-		Tokens      string `json:"tokens"`
-		Description struct {
-			Moniker         string `json:"moniker"`
-			Identity        string `json:"identity"`
-			Website         string `json:"website"`
-			SecurityContact string `json:"security_contact"`
-			Details         string `json:"details"`
-		} `json:"description"`
-	} `json:"result"`
-}
+const BOND_STATUS_BONDED = "BOND_STATUS_BONDED"
 
-type JunoErrorResponse struct {
-	Id      int    `json:"id"`
-	Jsonrpc string `json:"jsonrpc"`
-	Error   string `json:"error"`
+type JunoValidator struct {
+	Status string `json:"status"`
+	Tokens int64  `json:"tokens"`
+	Jailed bool   `json:"jailed"`
 }
 
 func Juno() (int, error) {
-	votingPowers := make([]int64, 0, 200)
+	var votingPowers []int64
 
-	url := fmt.Sprintf("https://lcd-juno.keplr.app/staking/validators")
+	url := fmt.Sprintf("https://juno.api.explorers.guru/api/validators")
 	resp, err := http.Get(url)
 	if err != nil {
-		errBody, _ := ioutil.ReadAll(resp.Body)
-		var errResp AgoricErrorResponse
-		json.Unmarshal(errBody, &errResp)
-		log.Println(errResp.Error)
 		return 0, err
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err
 	}
 
-	var response AgoricResponse
+	var response []JunoValidator
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		return 0, err
 	}
 
 	// loop through the validators voting powers
-	for _, ele := range response.Result {
-		val, _ := strconv.Atoi(ele.Tokens)
-		votingPowers = append(votingPowers, int64(val))
+	for _, ele := range response {
+		if ele.Jailed || ele.Status != BOND_STATUS_BONDED {
+			continue
+		}
+
+		votingPowers = append(votingPowers, ele.Tokens)
 	}
 
 	// need to sort the powers in descending order since they are in random order

--- a/core/chains/nano.go
+++ b/core/chains/nano.go
@@ -60,17 +60,21 @@ func nanoRequest[ReqType any, ResType any](url string, req ReqType) (*ResType, e
 	if err != nil {
 		return nil, err
 	}
+
 	resp, err := http.Post(url, "application/json", bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
 	}
+
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
+
 	if err = json.Unmarshal(body, &response); err != nil {
 		return nil, err
 	}
+
 	return &response, nil
 }
 


### PR DESCRIPTION
Fix juno by updating the validator rpc to use `https://juno.api.explorers.guru/api/validators`. The old rpc was non-functional.

category: bug 
ticket: none 