### PR TITLE
[aptos] Add support for aptos

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ NOTE: You can get your API Key by signing up [here](https://www.validators.app/u
 20. [Celestia](https://celestia.org/)
 21. [MultiversX](https://multiversx.com/)
 22. [Polkadot](https://polkadot.network/)
+23. [Aptos][https://aptosfoundation.org/]
 
 ### Notes
 

--- a/core/chains/aptos.go
+++ b/core/chains/aptos.go
@@ -77,5 +77,6 @@ func Aptos() (int, error) {
 
 	fmt.Printf("Total voting power: %s\n", calculatedTotalVotingPower.String())
 	fmt.Printf("The Nakomoto coefficient for Aptos is %d\n", coefficient)
-	return 1, nil
+
+	return coefficient, nil
 }

--- a/core/chains/aptos.go
+++ b/core/chains/aptos.go
@@ -1,0 +1,81 @@
+package chains
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/xenowits/nakamoto-coefficient-calculator/core/utils"
+)
+
+const AptosValidatorsUrl = "https://fullnode.mainnet.aptoslabs.com/v1/accounts/0x1/resource/0x1::stake::ValidatorSet"
+
+type AptosResponse struct {
+	Data struct {
+		ActiveValidators []struct {
+			VotingPower string `json:"voting_power"`
+		} `json:"active_validators"`
+		TotalVotingPower string `json:"total_voting_power"`
+	} `json:"data"`
+}
+
+func Aptos() (int, error) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelFunc()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, AptosValidatorsUrl, nil)
+	if err != nil {
+		log.Println(err)
+		return 0, errors.New("could not create get request for aptos")
+	}
+
+	resp, err := new(http.Client).Do(req)
+	if err != nil {
+		log.Println(err)
+		return 0, errors.New("get request failed for aptos")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	var response AptosResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return 0, errors.New("could not unmarshal response for aptos")
+	}
+
+	expectedTotalVotingPower, err := strconv.ParseInt(response.Data.TotalVotingPower, 10, 64)
+	if err != nil {
+		return 0, errors.New("failed to convert total voting power to int64")
+	}
+
+	var votingPowers []big.Int
+
+	for _, ele := range response.Data.ActiveValidators {
+		val, _ := strconv.Atoi(ele.VotingPower)
+		votingPowers = append(votingPowers, *big.NewInt(int64(val)))
+	}
+
+	calculatedTotalVotingPower := *utils.CalculateTotalVotingPowerBigNums(votingPowers)
+	coefficient := utils.CalcNakamotoCoefficientBigNums(&calculatedTotalVotingPower, votingPowers)
+
+	if expectedTotalVotingPower != calculatedTotalVotingPower.Int64() {
+		fmt.Printf("Expected total voting power: %d\n", expectedTotalVotingPower)
+		fmt.Printf("Calculated total voting power: %s\n", calculatedTotalVotingPower.String())
+		return 0, fmt.Errorf("total voting power mismatch: expected %d != calculated %s", expectedTotalVotingPower, calculatedTotalVotingPower.String())
+	}
+
+	fmt.Printf("Total voting power: %s\n", calculatedTotalVotingPower.String())
+	fmt.Printf("The Nakomoto coefficient for Aptos is %d\n", coefficient)
+	return 1, nil
+}

--- a/core/chains/chain.go
+++ b/core/chains/chain.go
@@ -20,6 +20,7 @@ type ChainState map[Token]Chain
 
 // Append new chains in alphabetical order only.
 const (
+	APT   Token = "APT"
 	ATOM  Token = "ATOM"
 	AVAX  Token = "AVAX"
 	BLD   Token = "BLD"
@@ -46,6 +47,8 @@ const (
 // ChainName returns the name of the chain given the token name.
 func (t Token) ChainName() string {
 	switch t {
+	case APT:
+		return "Aptos"
 	case ATOM:
 		return "Cosmos"
 	case AVAX:
@@ -93,7 +96,7 @@ func (t Token) ChainName() string {
 	}
 }
 
-var Tokens = []Token{ATOM, AVAX, BLD, BNB, DOT, EGLD, ETH2, GRT, HBAR, JUNO, MATIC, MINA, NEAR, OSMO, PLS, REGEN, RUNE, SOL, STARS, SUI, TIA}
+var Tokens = []Token{APT, ATOM, AVAX, BLD, BNB, DOT, EGLD, ETH2, GRT, HBAR, JUNO, MATIC, MINA, NEAR, OSMO, PLS, REGEN, RUNE, SOL, STARS, SUI, TIA}
 
 // NewState returns a new fresh state.
 func NewState() ChainState {
@@ -127,6 +130,8 @@ func newValues(token Token) (int, error) {
 	)
 
 	switch token {
+	case APT:
+		currVal, err = Aptos()
 	case ATOM:
 		currVal, err = Cosmos()
 	case AVAX:

--- a/core/utils/calc_nakamoto_coefficient.go
+++ b/core/utils/calc_nakamoto_coefficient.go
@@ -1,8 +1,13 @@
 package utils
 
+import "sort"
+
 func CalcNakamotoCoefficient(totalVotingPower int64, votingPowers []int64) int {
 	var cumulativePercent, thresholdPercent, curr float64 = 0.00, THRESHOLD_PERCENT, 0.00
 	nakamotoCoefficient := 0
+
+	sort.Slice(votingPowers, func(i, j int) bool { return votingPowers[i] > votingPowers[j] })
+
 	for _, vp := range votingPowers {
 		curr = float64(vp) / float64(totalVotingPower)
 		cumulativePercent += curr * 100

--- a/core/utils/calc_nakamoto_coefficient_big_nums.go
+++ b/core/utils/calc_nakamoto_coefficient_big_nums.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"math/big"
+	"sort"
 )
 
 func CalcNakamotoCoefficientBigNums(totalVotingPower *big.Int, votingPowers []big.Int) int {
@@ -9,6 +10,10 @@ func CalcNakamotoCoefficientBigNums(totalVotingPower *big.Int, votingPowers []bi
 	thresholdVal := new(big.Float).Mul(new(big.Float).SetInt(totalVotingPower), thresholdPercent)
 	cumulativeVal := big.NewFloat(0.00)
 	nakamotoCoefficient := 0
+
+	sort.Slice(votingPowers, func(i, j int) bool {
+		return votingPowers[i].Cmp(&votingPowers[j]) > 0
+	})
 
 	for _, vp := range votingPowers {
 		z := new(big.Float).Add(cumulativeVal, new(big.Float).SetInt(&vp))


### PR DESCRIPTION
Additionally, sort the votingPowers in CalcNakamotoCoefficient
    
These functions previously assume the list was sorted in descending order...
    
Rather than assume lets just sort those lists so that we cannot return an incorrect result
    
The first time I wrote this i got an incorrect result because it was not sorted

Test Plan:

Build / run locally

```
docker build . -t xenowits/nc-calc:v0.0.1 && docker run --rm \
-p 8080:8080 xenowits/nc-calc:v0.0.1
[+] Building 1.7s (18/18) FINISHED

...

Total voting power: 90604727551482931
The Nakomoto coefficient for Aptos is 18
Total voting power: 245586935196358
The Nakamoto coefficient for cosmos is 7

...
```