### PR TITLE
Update mina.go

### DIFF
--- a/core/chains/mina.go
+++ b/core/chains/mina.go
@@ -38,7 +38,7 @@ func reverse(numbers []float64) {
 
 func Mina() (int, error) {
 	var votingPowers []float64
-	var totalStake float64 // Added: variable to track the total stake
+	var totalStake float64
 	pageNo, entriesPerPage := 0, 50
 	url := ""
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
@@ -59,7 +59,7 @@ func Mina() (int, error) {
 			log.Println(err)
 			return 0, errors.New("get request unsuccessful")
 		}
-		defer resp.Body.Close() // Moved this line to ensure the body is always closed, even if an error occurs
+		defer resp.Body.Close()
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
@@ -72,12 +72,7 @@ func Mina() (int, error) {
 			return 0, err
 		}
 
-		// Original code:
-		// if len(response.Content) == 0 {
-		//     break
-		// }
-
-		// Updated condition: Break if no content or all pages have been fetched
+		// Break if no content or all pages have been fetched
 		if len(response.Content) == 0 || pageNo >= response.TotalPages {
 			break
 		}
@@ -85,36 +80,30 @@ func Mina() (int, error) {
 		// loop through the validators voting powers
 		for _, ele := range response.Content {
 			votingPowers = append(votingPowers, ele.StakePercent)
-			totalStake += ele.StakePercent // Added: Accumulate total stake of all validators
+			// Accumulate total stake of all validators
+			totalStake += ele.StakePercent
 		}
 
 		// increment counters
 		pageNo += 1
 	}
 
-	// Original sorting and reversal:
-	// sort.Float64s(votingPowers)
-	// reverse(votingPowers)
-
-	// Updated sorting: Sort voting powers in descending order
+	// Sort voting powers in descending order
 	sort.Slice(votingPowers, func(i, j int) bool {
 		return votingPowers[i] > votingPowers[j]
 	})
 
 	// now we're ready to calculate the Nakamoto coefficient
-	nakamotoCoefficient := calcNakamotoCoefficientForMina(votingPowers, totalStake) // Modified to pass totalStake
+	nakamotoCoefficient := calcNakamotoCoefficientForMina(votingPowers, totalStake)
 	fmt.Println("The Nakamoto coefficient for Mina is", nakamotoCoefficient)
 
 	return nakamotoCoefficient, nil
 }
 
-func calcNakamotoCoefficientForMina(votingPowers []float64, totalStake float64) int { // Modified to accept totalStake
-	// Original threshold calculation:
-	// var cumulativePercent, thresholdPercent float64 = 0.00, 50.00
-
-	// Updated to calculate the actual 50% threshold based on total stake
+func calcNakamotoCoefficientForMina(votingPowers []float64, totalStake float64) int {
+	// Calculate 50% threshold dynamically based on total stake
 	var cumulativePercent float64 = 0.00
-	thresholdPercent := totalStake * 0.50 // Calculate 50% threshold dynamically based on total stake
+	thresholdPercent := totalStake * 0.50
 	nakamotoCoefficient := 0
 
 	for _, vpp := range votingPowers {


### PR DESCRIPTION
Taking the code from: https://github.com/xenowits/nakomoto-coefficient-calculator/issues/59

Closes: https://github.com/xenowits/nakomoto-coefficient-calculator/issues/38
Closes: https://github.com/xenowits/nakomoto-coefficient-calculator/issues/59

Tested working by running `go run main.go`

```
2024/10/02 09:16:21 Calculating Nakamoto coefficient for Algo
Total voting power: 1264449527262260
The Nakamoto coefficient for Algorand is 10
2024/10/02 09:16:22 Successfully calculated Nakamoto coefficient for Algo: 10
2024/10/02 09:16:22 Calculating Nakamoto coefficient for Aptos
Total voting power: 86647076990866825
The Nakomoto coefficient for Aptos is 23
2024/10/02 09:16:25 Successfully calculated Nakamoto coefficient for Aptos: 23
2024/10/02 09:16:25 Calculating Nakamoto coefficient for Cosmos
2024/10/02 09:16:25 Fetching data for cosmos
2024/10/02 09:16:27 Voting powers for cosmos: 180 validators with a total voting power of 251261859069432
2024/10/02 09:16:27 The Nakamoto coefficient for cosmos is 7
2024/10/02 09:16:27 Successfully calculated Nakamoto coefficient for Cosmos: 7
2024/10/02 09:16:27 Calculating Nakamoto coefficient for Avalanche
Total voting power: 210452957171923092
The Nakamoto coefficient for Avalanche is 25
2024/10/02 09:16:28 Successfully calculated Nakamoto coefficient for Avalanche: 25
2024/10/02 09:16:28 Calculating Nakamoto coefficient for Agoric
2024/10/02 09:16:28 Fetching data for agoric
2024/10/02 09:16:30 Voting powers for agoric: 97 validators with a total voting power of 601351699150664
2024/10/02 09:16:30 The Nakamoto coefficient for agoric is 6
2024/10/02 09:16:30 Successfully calculated Nakamoto coefficient for Agoric: 6
2024/10/02 09:16:30 Calculating Nakamoto coefficient for BNB Smart Chain
The Nakamoto coefficient for BNB Smart Chain is 7
2024/10/02 09:16:31 Successfully calculated Nakamoto coefficient for BNB Smart Chain: 7
2024/10/02 09:16:31 Calculating Nakamoto coefficient for Polkadot
Total voting power: 8832896609170143564
The Nakamoto coefficient for Polkadot is 123
2024/10/02 09:16:33 Successfully calculated Nakamoto coefficient for Polkadot: 123
2024/10/02 09:16:33 Calculating Nakamoto coefficient for MultiversX
Total voting power: 3201
The Nakamoto coefficient for MultiversX is 8
2024/10/02 09:16:34 Successfully calculated Nakamoto coefficient for MultiversX: 8
2024/10/02 09:16:34 Calculating Nakamoto coefficient for Graph Protocol
Total voting power: 606587150229994033545772962
The Nakamoto coefficient for graph protocol is 3
2024/10/02 09:16:35 Successfully calculated Nakamoto coefficient for Graph Protocol: 3
2024/10/02 09:16:35 Calculating Nakamoto coefficient for Hedera
Total voting power for Hedera is: 2.0967741928e+10
The Nakamoto coefficient for Hedera is 7
2024/10/02 09:16:36 Successfully calculated Nakamoto coefficient for Hedera: 7
2024/10/02 09:16:36 Calculating Nakamoto coefficient for Juno
2024/10/02 09:16:36 Fetching data for juno
2024/10/02 09:16:38 Voting powers for juno: 100 validators with a total voting power of 50628485467111
2024/10/02 09:16:38 The Nakamoto coefficient for juno is 8
2024/10/02 09:16:38 Successfully calculated Nakamoto coefficient for Juno: 8
2024/10/02 09:16:38 Calculating Nakamoto coefficient for Polygon
Total voting power: 3493490378
The Nakamoto coefficient for 0xPolygon is 4
2024/10/02 09:16:41 Successfully calculated Nakamoto coefficient for Polygon: 4
2024/10/02 09:16:41 Calculating Nakamoto coefficient for Mina Protocol
The Nakamoto coefficient for Mina is 11
2024/10/02 09:16:46 Successfully calculated Nakamoto coefficient for Mina Protocol: 11
2024/10/02 09:16:46 Calculating Nakamoto coefficient for Near Protocol
Total voting power: 622511001023691052687778204513616
The Nakamoto coefficient for near protocol is 11
2024/10/02 09:16:47 Successfully calculated Nakamoto coefficient for Near Protocol: 11
2024/10/02 09:16:47 Calculating Nakamoto coefficient for Osmosis
2024/10/02 09:16:47 Fetching data for osmosis
2024/10/02 09:16:48 Voting powers for osmosis: 150 validators with a total voting power of 387112086261920
2024/10/02 09:16:48 The Nakamoto coefficient for osmosis is 8
2024/10/02 09:16:48 Successfully calculated Nakamoto coefficient for Osmosis: 8
2024/10/02 09:16:48 Calculating Nakamoto coefficient for Pulsechain
Total voting power: 622760463248
The Nakamoto coefficient for Pulsechain is 5
2024/10/02 09:16:49 Successfully calculated Nakamoto coefficient for Pulsechain: 5
2024/10/02 09:16:49 Calculating Nakamoto coefficient for Regen Network
2024/10/02 09:16:49 Fetching data for regen
2024/10/02 09:16:50 Voting powers for regen: 21 validators with a total voting power of 137633840818883
2024/10/02 09:16:50 The Nakamoto coefficient for regen is 5
2024/10/02 09:16:50 Successfully calculated Nakamoto coefficient for Regen Network: 5
2024/10/02 09:16:50 Calculating Nakamoto coefficient for Thorchain
Total voting power: 9804873707047115
The Nakamoto coefficient for thorchain is 31
2024/10/02 09:16:51 Successfully calculated Nakamoto coefficient for Thorchain: 31
2024/10/02 09:16:51 Calculating Nakamoto coefficient for Sei
2024/10/02 09:16:51 Attempting to calculate Sei Nakamoto coefficient...
2024/10/02 09:16:51 Fetching data for sei
2024/10/02 09:16:52 Voting powers for sei: 39 validators with a total voting power of 5423684392022587
2024/10/02 09:16:52 The Nakamoto coefficient for sei is 8
2024/10/02 09:16:52 Successfully calculated Nakamoto coefficient for Sei: 8
2024/10/02 09:16:52 Calculating Nakamoto coefficient for Solana
2024/10/02 09:16:52 Error in chain Solana: json: cannot unmarshal object into Go value of type chains.SolanaResponse
2024/10/02 09:16:52 Failed to update chain info: SOL json: cannot unmarshal object into Go value of type chains.SolanaResponse
2024/10/02 09:16:52 Calculating Nakamoto coefficient for Stargaze
2024/10/02 09:16:52 Attempting to calculate Stargaze Nakamoto coefficient...
2024/10/02 09:16:52 Fetching data for stargaze
2024/10/02 09:16:53 Voting powers for stargaze: 129 validators with a total voting power of 1056493403698422
2024/10/02 09:16:53 The Nakamoto coefficient for stargaze is 11
2024/10/02 09:16:53 Successfully calculated Nakamoto coefficient for Stargaze: 11
2024/10/02 09:16:53 Calculating Nakamoto coefficient for Sui Protocol
Total voting power for sui: 10000
The Nakamoto coefficient for sui is 16
2024/10/02 09:16:54 Successfully calculated Nakamoto coefficient for Sui Protocol: 16
2024/10/02 09:16:54 Calculating Nakamoto coefficient for Celestia
The Nakamoto coefficient for celestia is 8
2024/10/02 09:16:55 Successfully calculated Nakamoto coefficient for Celestia: 8
```