### PR TITLE
Refactor Nano code to calculate NC based on 67% cumulative voting power

### DIFF
--- a/core/chains/nano.go
+++ b/core/chains/nano.go
@@ -121,7 +121,7 @@ func Nano() (int, error) {
 
 	// Calculate total voting power
 	calculatedTotalVotingPower := utils.CalculateTotalVotingPowerBigNums(votingPowers)
-	thresholdVotingPower := new(big.Int).Mul(calculatedTotalVotingPower, big.NewInt(67))
+	thresholdVotingPower := new(big.Int).Mul(calculatedTotalVotingPower, big.NewInt(THRESHOLD))
 	thresholdVotingPower.Div(thresholdVotingPower, big.NewInt(100))
 
 	// Sort the voting powers in descending order

--- a/core/chains/nano.go
+++ b/core/chains/nano.go
@@ -2,43 +2,146 @@ package chains
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
+	"math/big"
 	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/xenowits/nakamoto-coefficient-calculator/core/utils"
 )
 
-// NanoStats represents the structure for Nano's stats data from nanocharts.
-type NanoStats struct {
-	Stats struct {
-		C1s struct {
-			N int `json:"n"`
-		} `json:"c1s"`
-	} `json:"stats"`
+type NanExplorerResponse struct {
+	Rep []struct {
+		Account string `json:"account"`
+		Weight  string `json:"weight"`
+	} `json:"rep"`
+	OnlineStakeTotal string `json:"online_stake_total"`
 }
 
+type EntityResponse struct {
+	Timestamp int64 `json:"timestamp"`
+	Entities  []struct {
+		Entity          string   `json:"entity"`
+		Representatives []string `json:"representatives"`
+	} `json:"entities"`
+}
+
+const (
+	THRESHOLD = 67 // 67% threshold for Nakamoto Coefficient
+)
+
 func Nano() (int, error) {
-	chartsURL := "https://nanocharts.info/data/nanocharts.json"
 
-	log.Println("Fetching data for Nano")
-
-	// Fetch the data from nanocharts
-	resp, err := http.Get(chartsURL)
+	// Step 1: Fetch entity groups
+	resp, err := http.Get("https://nanocharts.info/data/entities.json")
 	if err != nil {
-		log.Println("Error fetching data from nanocharts:", err)
+		log.Println("Error fetching entities:", err)
 		return 0, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("Entities fetch failed: %d", resp.StatusCode)
+		return 0, fmt.Errorf("entities fetch failed: %d", resp.StatusCode)
+	}
 
-	var data NanoStats
-
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		log.Println("Error decoding JSON:", err)
+	var entityData EntityResponse
+	if err := json.NewDecoder(resp.Body).Decode(&entityData); err != nil {
+		log.Println("Error decoding entities JSON:", err)
 		return 0, err
 	}
 
-	// The Nakamoto coefficient is directly available in the JSON under stats.c1s.n!
-	nakamotoCoefficient := data.Stats.C1s.N
+	entityGroups := make(map[string][]string)
+	for _, entity := range entityData.Entities {
+		entityGroups[entity.Entity] = entity.Representatives
+	}
 
-	log.Println("The Nakamoto coefficient for Nano is", nakamotoCoefficient)
+	// Step 2: Fetch online reps and weights from NanExplorer
+	resp, err = http.Get("https://api.nanexplorer.com/representatives_online?network=nano")
+	if err != nil {
+		log.Println("Error fetching online reps:", err)
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("NanExplorer fetch failed: %d", resp.StatusCode)
+		return 0, fmt.Errorf("nanexplorer fetch failed: %d", resp.StatusCode)
+	}
 
-	return nakamotoCoefficient, nil
+	var explorerData NanExplorerResponse
+	if err := json.NewDecoder(resp.Body).Decode(&explorerData); err != nil {
+		log.Println("Error decoding nanexplorer data:", err)
+		return 0, err
+	}
+
+	// Step 3: Process weights into big.Int
+	weights := make(map[string]*big.Int)
+	accountToEntity := make(map[string]string)
+
+	for entity, reps := range entityGroups {
+		for _, acc := range reps {
+			accountToEntity[acc] = entity
+		}
+	}
+
+	for _, rep := range explorerData.Rep {
+		weight, err := strconv.ParseFloat(rep.Weight, 64)
+		if err != nil {
+			log.Printf("Error parsing weight for %s: %v", rep.Account, err)
+			continue
+		}
+		weightInt := new(big.Int).SetInt64(int64(weight * 1e6)) // Convert XNO to raw-like integer
+
+		entityName, ok := accountToEntity[rep.Account]
+		if !ok {
+			entityName = rep.Account
+		}
+		if _, ok := weights[entityName]; !ok {
+			weights[entityName] = new(big.Int)
+		}
+		weights[entityName].Add(weights[entityName], weightInt)
+	}
+
+	// Step 4: Collect voting powers as big.Int (not pointers)
+	var votingPowers []big.Int
+	for _, weight := range weights {
+		// Copy the value of weight to the slice of big.Int
+		votingPowers = append(votingPowers, *weight)
+
+		// log.Printf("Entity: %s, Weight: %s XNO", weight.String(), weight.String())
+	}
+
+	if len(votingPowers) == 0 {
+		log.Println("No weights processed - no online reps")
+		return 0, fmt.Errorf("no weights")
+	}
+
+	// Manually accumulate voting power until we hit the threshold
+
+	// Calculate total voting power
+	calculatedTotalVotingPower := utils.CalculateTotalVotingPowerBigNums(votingPowers)
+	thresholdVotingPower := new(big.Int).Mul(calculatedTotalVotingPower, big.NewInt(67))
+	thresholdVotingPower.Div(thresholdVotingPower, big.NewInt(100))
+
+	// Sort the voting powers in descending order
+	sort.Slice(votingPowers, func(i, j int) bool {
+		return votingPowers[i].Cmp(&votingPowers[j]) > 0
+	})
+
+	// Step 5: Accumulate until the threshold is met
+	var accumulatedVotingPower big.Int
+	for i, power := range votingPowers {
+		accumulatedVotingPower.Add(&accumulatedVotingPower, &power)
+		if accumulatedVotingPower.Cmp(thresholdVotingPower) >= 0 {
+
+			log.Printf("Nakamoto Coefficient (67%%): %d", i+1) // Number of entities needed to meet threshold
+
+			return i + 1, nil
+		}
+	}
+
+	// In case we have all entities
+	// log.Printf("Nakamoto Coefficient (67%%): %d", len(votingPowers))
+	return len(votingPowers), nil
 }

--- a/core/chains/nano.go
+++ b/core/chains/nano.go
@@ -108,8 +108,6 @@ func Nano() (int, error) {
 	for _, weight := range weights {
 		// Copy the value of weight to the slice of big.Int
 		votingPowers = append(votingPowers, *weight)
-
-		// log.Printf("Entity: %s, Weight: %s XNO", weight.String(), weight.String())
 	}
 
 	if len(votingPowers) == 0 {


### PR DESCRIPTION
Hi @xenowits,

Thank you for your feedback. I've made updates to the Nano implementation to properly calculate the Nakamoto Coefficient by explicitly computing cumulative voting power for the validators. Instead of fetching `data.Stats.C1s.N` from the NanoCharts API, the code now manually accumulates the voting power until the 67% threshold is reached, which is the approach used by other chains in the repository.

This change improves transparency, as the validator weights and thresholds are now explicitly referenced in the code.

You can find the updated Nano code in the following implementation.

Let me know if you’d like further adjustments or if there’s anything else to refine.

Best,
Brazy