### PR TITLE
fixed monad RPC rate limit 

### DIFF
--- a/core/chains/monad.go
+++ b/core/chains/monad.go
@@ -51,6 +51,7 @@ func Monad() (int, error) {
 
 	// 2. Fetch stake for each validator
 	for _, id := range valIDs {
+		time.Sleep(50 * time.Millisecond)
 		stake, err := fetchValidatorStake(id)
 		if err != nil {
 			log.Printf("Failed to fetch stake for ValID %s: %v", id.String(), err)


### PR DESCRIPTION
Added a 50ms client-side throttle (`time.Sleep`) between validator fetch requests.